### PR TITLE
Auto generated sitemap and robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# next-sitemap
+public/robots.txt
+public/sitemap*.xml

--- a/buildScripts/postbuild.js
+++ b/buildScripts/postbuild.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+// For some reason next-sitemap copies sitemaps and robots.txt from public BEFORE generating them
+// so public ends up having the correct sitemaps but out ends up with outdated sitemaps
+// so this script will copy robots.txt and sitemap*.xml from public to out
+// bash scripts make it terminal dependent since pwsh doesnt have the cp or mv
+
+fs.readdirSync('./public').forEach(file => {
+    const sitemapRegex = new RegExp(/^sitemap.*\.xml$/);
+    if(file === 'robots.txt' || sitemapRegex.test(file)) {
+        fs.copyFileSync(`./public/${file}`, `./out/${file}`);
+        console.log(`Copied: ./public/${file} -> ./out/${file}`);
+    }
+});

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,0 +1,22 @@
+/** @type {import('next-sitemap').IConfig} */
+module.exports = {
+    siteUrl: 'https://iiitdwd.ac.in',
+    generateRobotsTxt: true,
+    robotsTxtOptions: {
+        policies: [
+            { userAgent: "*", disallow: "/faculty/*" },
+            { userAgent: "*", disallow: "/events/*" },
+            { userAgent: "*", allow: "/" },
+        ],
+    },
+    exclude: ["/faculty/*", "/events/*"],
+    transform: async (config, path) => {
+        return {
+            loc: path, // => this will be exported as http(s)://<config.siteUrl>/<path>
+            changefreq: config.changefreq,
+            priority: 1 - (path.split('/').length - 1) / 10,
+            lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+            alternateRefs: config.alternateRefs ?? [],
+        }
+    },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "14.2.3",
+        "next-sitemap": "^4.2.3",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -64,6 +65,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@corex/deepmerge": {
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/@corex/deepmerge/-/deepmerge-4.0.43.tgz",
+      "integrity": "sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
@@ -4029,6 +4037,41 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-sitemap": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/next-sitemap/-/next-sitemap-4.2.3.tgz",
+      "integrity": "sha512-vjdCxeDuWDzldhCnyFCQipw5bfpl4HmZA7uoo3GAaYGjGgfL4Cxb1CiztPuWGmS+auYs7/8OekRS8C2cjdAsjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "url": "https://github.com/iamvishnusankar/next-sitemap.git"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@corex/deepmerge": "^4.0.43",
+        "@next/env": "^13.4.3",
+        "fast-glob": "^3.2.12",
+        "minimist": "^1.2.8"
+      },
+      "bin": {
+        "next-sitemap": "bin/next-sitemap.mjs",
+        "next-sitemap-cjs": "bin/next-sitemap.cjs"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "next": "*"
+      }
+    },
+    "node_modules/next-sitemap/node_modules/@next/env": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
+      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "next-sitemap && node buildScripts/postbuild.js",
     "start": "next start",
     "lint": "next lint --fix"
   },
@@ -39,6 +40,7 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",
+    "next-sitemap": "^4.2.3",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"


### PR DESCRIPTION
Set up next-sitemap to auto generate sitemaps and robots.txt while building. I've configured it to set the priority of every page to be `1 - 0.1 * <number of / in its path>`. This also adds `buildScripts/postbuild.js` to copy some files because next-sitemap was behaving a little weird with SSG.